### PR TITLE
Add GPIO button input for basys3 directional buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,20 @@ Required to assemble the simulation test programs (`make sim-test`). Not needed 
 - **Linux (Ubuntu 22.04 and earlier):** `sudo apt-get install -y gcc-riscv64-unknown-elf`
 
 ## :rocket: Getting started
-For now a simple program turns on one LED, sends "PASS" and turn on the eigth rightmost LEDs. 
+After boot, the program prints "PASS" over UART and enters button mode.
+Pressing any of the four directional buttons (btnU, btnL, btnR, btnD) 
+will light up the corresponding LED (0-3).
 **Note:** When CPU is running, the leftmost LED is lit.
+
+### Memory Map
+
+| Address        | Description                                      |
+|----------------|--------------------------------------------------|
+| `0x0000_0000`  | Scratchpad RAM (4 KB)                            |
+| `0xF000_0000`  | UART status (bit 0 = TX ready, bit 1 = RX ready)|
+| `0xF000_0004`  | UART data (read = RX, write = TX)                |
+| `0xF010_0000`  | LED register (bit 0-6 = LED 0-6, bit 7 = CPU running indicator (read-only), bit 8-15 = LED 8-15) |
+| `0xF020_0000`  | Button register (bit 0-3 = btnU, btnL, btnR, btnD, read-only) |
 
 ### 1. Clone repo
 ```bash

--- a/dfx_runtime.txt
+++ b/dfx_runtime.txt
@@ -1,0 +1,2 @@
+DFXRuntime Profile Report:
+Total Application(DFX) Runtime :                  CPU : 0:0:3 WALL : 0:0:0  0.00 % 

--- a/hw/constraints/basys3.xdc
+++ b/hw/constraints/basys3.xdc
@@ -50,10 +50,10 @@ set_property PACKAGE_PIN L1  [get_ports {io_led[7]}]
 	
 ##Buttons
 set_property PACKAGE_PIN U18 [get_ports reset]						
-#set_property PACKAGE_PIN T18 [get_ports btnU]						
-#set_property PACKAGE_PIN W19 [get_ports btnL]						
-#set_property PACKAGE_PIN T17 [get_ports btnR]						
-#set_property PACKAGE_PIN U17 [get_ports btnD]						
+set_property PACKAGE_PIN T18 [get_ports io_btn[0]]						
+set_property PACKAGE_PIN W19 [get_ports io_btn[1]]						
+set_property PACKAGE_PIN T17 [get_ports io_btn[2]]						
+set_property PACKAGE_PIN U17 [get_ports io_btn[3]]						
 
 
 ##7 segment display

--- a/sw/program/src/main.rs
+++ b/sw/program/src/main.rs
@@ -9,6 +9,7 @@ use core::panic::PanicInfo; // for our custom panic handler
 const UART_STATUS: *const u32 = 0xF000_0000 as *const u32;
 const UART_DATA: *mut u32 = 0xF000_0004 as *mut u32;
 const LED_REG: *mut u32 = 0xF010_0000 as *mut u32;
+const BTN_REG: *const u32 = 0xF020_0000 as *const u32;
 
 // ── 2. Linker symboler (Fra linker.ld) ──────────────────────────────────────
 extern "C" {
@@ -85,10 +86,16 @@ macro_rules! println {
     ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }
 
-// ── 7. HAL: LED helper ─────────────────────────────────────────────────────
+// ── 7. HAL: LED helper + BTN helper ─────────────────────────────────────────────────────
 fn led_write(val: u16) { // LED = 1 on, LED = 0 off, bitmask for 16 LEDs
     unsafe {
         LED_REG.write_volatile(val as u32);
+    }
+}
+
+fn btn_read() -> u32 {
+    unsafe {
+        BTN_REG.read_volatile()
     }
 }
 
@@ -104,6 +111,14 @@ fn main() {
 
     // Tænd 7 mest højrestående LEDer på boardet + RØD og GRØN LED
     led_write(0x3FF);
+
+    // Button-blink demo: LEDs afspejler knaptryk
+    // Note: Physical LED 7 is hardwired to the cpuRunning signal and cannot be controlled from software
+    println!("Entering button mode...");
+    loop {
+        let buttons = btn_read();
+        led_write(buttons as u16);
+    }
 }
 
 // ── 9. Panic Handler ────────────────────────────────────────────────────────

--- a/wildcat/generated/RustSoCTop.v
+++ b/wildcat/generated/RustSoCTop.v
@@ -1483,9 +1483,10 @@ endmodule
 module RustSoCTop(
   input         clock,
   input         reset,
-  output [15:0] io_led, // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 44:14]
-  output        io_tx, // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 44:14]
-  input         io_rx // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 44:14]
+  output [15:0] io_led, // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 45:14]
+  output        io_tx, // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 45:14]
+  input         io_rx, // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 45:14]
+  input  [3:0]  io_btn // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 45:14]
 );
 `ifdef RANDOMIZE_REG_INIT
   reg [31:0] _RAND_0;
@@ -1496,81 +1497,83 @@ module RustSoCTop(
   reg [31:0] _RAND_5;
   reg [31:0] _RAND_6;
 `endif // RANDOMIZE_REG_INIT
-  wire  resetRx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire  resetRx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire  resetRx_io_rxd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire  resetRx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire  resetRx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire [7:0] resetRx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
-  wire  bootloader_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire  bootloader_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire [31:0] bootloader_io_instrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire [31:0] bootloader_io_instrAddr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire  bootloader_io_wrEnabled; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire  bootloader_io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
-  wire  cpu_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire  cpu_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [31:0] cpu_io_imem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [31:0] cpu_io_imem_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire  cpu_io_imem_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [31:0] cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire  cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire  cpu_io_dmem_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [31:0] cpu_io_dmem_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [31:0] cpu_io_dmem_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire [3:0] cpu_io_dmem_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
-  wire  imem_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire  imem_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire [31:0] imem_io_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire  imem_io_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire  imem_io_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire [31:0] imem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire [31:0] imem_io_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire [3:0] imem_io_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire  imem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
-  wire  dmem_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire  dmem_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire [31:0] dmem_io_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire  dmem_io_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire  dmem_io_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire [31:0] dmem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire [31:0] dmem_io_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire [3:0] dmem_io_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire  dmem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
-  wire  uartTx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire  uartTx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire  uartTx_io_txd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire  uartTx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire  uartTx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire [7:0] uartTx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
-  wire  uartRx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  wire  uartRx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  wire  uartRx_io_rxd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  wire  uartRx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  wire  uartRx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  wire [7:0] uartRx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
-  reg [31:0] resetShift; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 59:27]
-  wire [31:0] _resetShift_T_1 = {resetRx_io_channel_bits,resetShift[31:8]}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 61:43]
-  wire  softReset = resetShift == 32'hdeadbeef; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 65:19]
-  wire  combinedReset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 72:37]
-  reg  cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 75:54]
-  wire  _T_1 = ~cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 85:8]
-  wire  _T_3 = ~cpuRunning & bootloader_io_wrEnabled; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 85:20]
-  wire  _GEN_3 = ~cpuRunning & bootloader_io_wrEnabled & bootloader_io_instrData == 32'hd0000000 | cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 85:97 86:16 75:54]
-  wire  _GEN_10 = _T_3 & bootloader_io_instrData != 32'hd0000000 | cpu_io_dmem_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 111:97 121:21]
-  wire [31:0] _GEN_16 = _T_1 ? 32'h0 : dmem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 130:21 133:24]
-  reg [1:0] uartStatusReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 153:30]
-  reg [31:0] memAddressReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 154:30]
-  wire [31:0] _GEN_18 = memAddressReg[3:0] == 4'h4 ? {{24'd0}, uartRx_io_channel_bits} : _GEN_16; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 160:45 161:26]
-  wire  _GEN_19 = memAddressReg[3:0] == 4'h4 & cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 150:27 160:45 162:31]
-  wire [31:0] _GEN_20 = memAddressReg[3:0] == 4'h0 ? {{30'd0}, uartStatusReg} : _GEN_18; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 158:39 159:26]
-  wire  _GEN_21 = memAddressReg[3:0] == 4'h0 ? 1'h0 : _GEN_19; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 150:27 158:39]
-  reg [15:0] ledReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 167:50]
-  wire  _T_30 = cpu_io_dmem_address[23:20] == 4'h0 & cpu_io_dmem_address[3:0] == 4'h4; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 169:46]
-  reg [7:0] io_led_REG; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:20]
-  wire [8:0] _io_led_T_1 = {io_led_REG,cpuRunning}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:36]
-  reg [6:0] io_led_REG_1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:60]
-  Rx resetRx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 55:23]
+  wire  resetRx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire  resetRx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire  resetRx_io_rxd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire  resetRx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire  resetRx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire [7:0] resetRx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
+  wire  bootloader_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire  bootloader_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire [31:0] bootloader_io_instrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire [31:0] bootloader_io_instrAddr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire  bootloader_io_wrEnabled; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire  bootloader_io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
+  wire  cpu_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire  cpu_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [31:0] cpu_io_imem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [31:0] cpu_io_imem_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire  cpu_io_imem_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [31:0] cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire  cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire  cpu_io_dmem_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [31:0] cpu_io_dmem_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [31:0] cpu_io_dmem_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire [3:0] cpu_io_dmem_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
+  wire  imem_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire  imem_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire [31:0] imem_io_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire  imem_io_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire  imem_io_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire [31:0] imem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire [31:0] imem_io_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire [3:0] imem_io_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire  imem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
+  wire  dmem_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire  dmem_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire [31:0] dmem_io_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire  dmem_io_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire  dmem_io_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire [31:0] dmem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire [31:0] dmem_io_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire [3:0] dmem_io_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire  dmem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
+  wire  uartTx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire  uartTx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire  uartTx_io_txd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire  uartTx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire  uartTx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire [7:0] uartTx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
+  wire  uartRx_clock; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  wire  uartRx_reset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  wire  uartRx_io_rxd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  wire  uartRx_io_channel_ready; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  wire  uartRx_io_channel_valid; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  wire [7:0] uartRx_io_channel_bits; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
+  reg [31:0] resetShift; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 61:27]
+  wire [31:0] _resetShift_T_1 = {resetRx_io_channel_bits,resetShift[31:8]}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 63:43]
+  wire  softReset = resetShift == 32'hdeadbeef; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 67:19]
+  wire  combinedReset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 74:37]
+  reg  cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 77:54]
+  wire  _T_1 = ~cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 87:8]
+  wire  _T_3 = ~cpuRunning & bootloader_io_wrEnabled; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 87:20]
+  wire  _GEN_3 = ~cpuRunning & bootloader_io_wrEnabled & bootloader_io_instrData == 32'hd0000000 | cpuRunning; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 87:97 88:16 77:54]
+  wire  _GEN_10 = _T_3 & bootloader_io_instrData != 32'hd0000000 | cpu_io_dmem_wr; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 113:97 123:21]
+  wire [31:0] _GEN_16 = _T_1 ? 32'h0 : dmem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 132:21 135:24]
+  reg [1:0] uartStatusReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 155:30]
+  reg [31:0] memAddressReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 156:30]
+  wire  _T_14 = cpuRunning & memAddressReg[31:28] == 4'hf; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 159:19]
+  wire [31:0] _GEN_18 = memAddressReg[3:0] == 4'h4 ? {{24'd0}, uartRx_io_channel_bits} : _GEN_16; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 162:45 163:26]
+  wire  _GEN_19 = memAddressReg[3:0] == 4'h4 & cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 152:27 162:45 164:31]
+  wire [31:0] _GEN_20 = memAddressReg[3:0] == 4'h0 ? {{30'd0}, uartStatusReg} : _GEN_18; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 160:39 161:26]
+  wire  _GEN_21 = memAddressReg[3:0] == 4'h0 ? 1'h0 : _GEN_19; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 152:27 160:39]
+  wire [31:0] _GEN_22 = cpuRunning & memAddressReg[31:28] == 4'hf & memAddressReg[23:20] == 4'h0 ? _GEN_20 : _GEN_16; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 159:88]
+  reg [15:0] ledReg; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 174:50]
+  wire  _T_36 = cpu_io_dmem_address[23:20] == 4'h0 & cpu_io_dmem_address[3:0] == 4'h4; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 176:46]
+  reg [7:0] io_led_REG; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:20]
+  wire [8:0] _io_led_T_1 = {io_led_REG,cpuRunning}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:36]
+  reg [6:0] io_led_REG_1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:60]
+  Rx resetRx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:23]
     .clock(resetRx_clock),
     .reset(resetRx_reset),
     .io_rxd(resetRx_io_rxd),
@@ -1578,7 +1581,7 @@ module RustSoCTop(
     .io_channel_valid(resetRx_io_channel_valid),
     .io_channel_bits(resetRx_io_channel_bits)
   );
-  BootloaderTop bootloader ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 81:53]
+  BootloaderTop bootloader ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 83:53]
     .clock(bootloader_clock),
     .reset(bootloader_reset),
     .io_instrData(bootloader_io_instrData),
@@ -1586,7 +1589,7 @@ module RustSoCTop(
     .io_wrEnabled(bootloader_io_wrEnabled),
     .io_rx(bootloader_io_rx)
   );
-  ThreeCats cpu ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 91:46]
+  ThreeCats cpu ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 93:46]
     .clock(cpu_clock),
     .reset(cpu_reset),
     .io_imem_address(cpu_io_imem_address),
@@ -1599,7 +1602,7 @@ module RustSoCTop(
     .io_dmem_wrData(cpu_io_dmem_wrData),
     .io_dmem_wrMask(cpu_io_dmem_wrMask)
   );
-  ScratchPadMem imem ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 99:20]
+  ScratchPadMem imem ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 101:20]
     .clock(imem_clock),
     .reset(imem_reset),
     .io_address(imem_io_address),
@@ -1610,7 +1613,7 @@ module RustSoCTop(
     .io_wrMask(imem_io_wrMask),
     .io_ack(imem_io_ack)
   );
-  ScratchPadMem dmem ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 100:20]
+  ScratchPadMem dmem ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 102:20]
     .clock(dmem_clock),
     .reset(dmem_reset),
     .io_address(dmem_io_address),
@@ -1621,7 +1624,7 @@ module RustSoCTop(
     .io_wrMask(dmem_io_wrMask),
     .io_ack(dmem_io_ack)
   );
-  BufferedTx uartTx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 139:49]
+  BufferedTx uartTx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 141:49]
     .clock(uartTx_clock),
     .reset(uartTx_reset),
     .io_txd(uartTx_io_txd),
@@ -1629,7 +1632,7 @@ module RustSoCTop(
     .io_channel_valid(uartTx_io_channel_valid),
     .io_channel_bits(uartTx_io_channel_bits)
   );
-  Rx uartRx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 140:49]
+  Rx uartRx ( // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 142:49]
     .clock(uartRx_clock),
     .reset(uartRx_reset),
     .io_rxd(uartRx_io_rxd),
@@ -1637,71 +1640,70 @@ module RustSoCTop(
     .io_channel_valid(uartRx_io_channel_valid),
     .io_channel_bits(uartRx_io_channel_bits)
   );
-  assign io_led = {_io_led_T_1,io_led_REG_1}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:50]
-  assign io_tx = cpuRunning ? uartTx_io_txd : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 143:15]
+  assign io_led = {_io_led_T_1,io_led_REG_1}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:50]
+  assign io_tx = cpuRunning ? uartTx_io_txd : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 145:15]
   assign resetRx_clock = clock;
   assign resetRx_reset = reset;
-  assign resetRx_io_rxd = io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 56:18]
-  assign resetRx_io_channel_ready = 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 57:28]
+  assign resetRx_io_rxd = io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 58:18]
+  assign resetRx_io_channel_ready = 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 59:28]
   assign bootloader_clock = clock;
-  assign bootloader_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 72:37]
-  assign bootloader_io_rx = cpuRunning | io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 82:26]
+  assign bootloader_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 74:37]
+  assign bootloader_io_rx = cpuRunning | io_rx; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 84:26]
   assign cpu_clock = clock;
-  assign cpu_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 72:37]
-  assign cpu_io_imem_rdData = _T_1 ? 32'h33 : imem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 130:21 131:24]
-  assign cpu_io_imem_ack = _T_1 ? 1'h0 : imem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 130:21 132:24]
-  assign cpu_io_dmem_rdData = cpuRunning & memAddressReg[31:28] == 4'hf & memAddressReg[23:20] == 4'h0 ? _GEN_20 :
-    _GEN_16; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 157:88]
+  assign cpu_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 74:37]
+  assign cpu_io_imem_rdData = _T_1 ? 32'h33 : imem_io_rdData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 132:21 133:24]
+  assign cpu_io_imem_ack = _T_1 ? 1'h0 : imem_io_ack; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 132:21 134:24]
+  assign cpu_io_dmem_rdData = _T_14 & memAddressReg[23:20] == 4'h2 ? {{28'd0}, io_btn} : _GEN_22; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 169:90 170:24]
   assign imem_clock = clock;
   assign imem_reset = reset;
   assign imem_io_address = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrAddr :
-    cpu_io_imem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 111:97 113:21]
-  assign imem_io_rd = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 1'h0 : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 111:97 117:21]
-  assign imem_io_wr = _T_3 & bootloader_io_instrData != 32'hd0000000; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 111:55]
-  assign imem_io_wrData = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrData : 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 111:97 115:21]
-  assign imem_io_wrMask = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 4'hf : 4'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 104:15 111:97 116:21]
+    cpu_io_imem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 113:97 115:21]
+  assign imem_io_rd = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 1'h0 : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 113:97 119:21]
+  assign imem_io_wr = _T_3 & bootloader_io_instrData != 32'hd0000000; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 113:55]
+  assign imem_io_wrData = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrData : 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 113:97 117:21]
+  assign imem_io_wrMask = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 4'hf : 4'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 106:15 113:97 118:21]
   assign dmem_clock = clock;
   assign dmem_reset = reset;
   assign dmem_io_address = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrAddr :
-    cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 111:97 120:21]
-  assign dmem_io_rd = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 1'h0 : cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 111:97 124:21]
-  assign dmem_io_wr = cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr ? 1'h0 : _GEN_10; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 168:81 177:16]
-  assign dmem_io_wrData = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrData : cpu_io_dmem_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 111:97 122:21]
-  assign dmem_io_wrMask = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 4'hf : cpu_io_dmem_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 105:15 111:97 123:21]
+    cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 113:97 122:21]
+  assign dmem_io_rd = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 1'h0 : cpu_io_dmem_rd; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 113:97 126:21]
+  assign dmem_io_wr = cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr ? 1'h0 : _GEN_10; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 175:81 184:16]
+  assign dmem_io_wrData = _T_3 & bootloader_io_instrData != 32'hd0000000 ? bootloader_io_instrData : cpu_io_dmem_wrData; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 113:97 124:21]
+  assign dmem_io_wrMask = _T_3 & bootloader_io_instrData != 32'hd0000000 ? 4'hf : cpu_io_dmem_wrMask; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 107:15 113:97 125:21]
   assign uartTx_clock = clock;
-  assign uartTx_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 72:37]
-  assign uartTx_io_channel_valid = cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr & _T_30; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 149:27 168:81]
-  assign uartTx_io_channel_bits = cpu_io_dmem_wrData[7:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 148:48]
+  assign uartTx_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 74:37]
+  assign uartTx_io_channel_valid = cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr & _T_36; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 151:27 175:81]
+  assign uartTx_io_channel_bits = cpu_io_dmem_wrData[7:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 150:48]
   assign uartRx_clock = clock;
-  assign uartRx_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 72:37]
-  assign uartRx_io_rxd = cpuRunning ? io_rx : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 145:23]
-  assign uartRx_io_channel_ready = cpuRunning & memAddressReg[31:28] == 4'hf & memAddressReg[23:20] == 4'h0 & _GEN_21; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 150:27 157:88]
+  assign uartRx_reset = reset | softReset; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 74:37]
+  assign uartRx_io_rxd = cpuRunning ? io_rx : 1'h1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 147:23]
+  assign uartRx_io_channel_ready = cpuRunning & memAddressReg[31:28] == 4'hf & memAddressReg[23:20] == 4'h0 & _GEN_21; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 152:27 159:88]
   always @(posedge clock) begin
-    if (reset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 59:27]
-      resetShift <= 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 59:27]
-    end else if (softReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 65:35]
-      resetShift <= 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 67:16]
-    end else if (resetRx_io_channel_valid) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 60:34]
-      resetShift <= _resetShift_T_1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 61:16]
+    if (reset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 61:27]
+      resetShift <= 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 61:27]
+    end else if (softReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 67:35]
+      resetShift <= 32'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 69:16]
+    end else if (resetRx_io_channel_valid) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 62:34]
+      resetShift <= _resetShift_T_1; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 63:16]
     end
-    if (combinedReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 75:54]
-      cpuRunning <= 1'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 75:54]
+    if (combinedReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 77:54]
+      cpuRunning <= 1'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 77:54]
     end else begin
       cpuRunning <= _GEN_3;
     end
-    uartStatusReg <= {uartRx_io_channel_valid,uartTx_io_channel_ready}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 153:55]
-    memAddressReg <= cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 154:30]
-    if (combinedReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 167:50]
-      ledReg <= 16'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 167:50]
-    end else if (cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 168:81]
-      if (!(cpu_io_dmem_address[23:20] == 4'h0 & cpu_io_dmem_address[3:0] == 4'h4)) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 169:84]
-        if (cpu_io_dmem_address[23:20] == 4'h1) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 172:53]
-          ledReg <= cpu_io_dmem_wrData[15:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 174:14]
+    uartStatusReg <= {uartRx_io_channel_valid,uartTx_io_channel_ready}; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 155:55]
+    memAddressReg <= cpu_io_dmem_address; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 156:30]
+    if (combinedReset) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 174:50]
+      ledReg <= 16'h0; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 174:50]
+    end else if (cpuRunning & cpu_io_dmem_address[31:28] == 4'hf & cpu_io_dmem_wr) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 175:81]
+      if (!(cpu_io_dmem_address[23:20] == 4'h0 & cpu_io_dmem_address[3:0] == 4'h4)) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 176:84]
+        if (cpu_io_dmem_address[23:20] == 4'h1) begin // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 179:53]
+          ledReg <= cpu_io_dmem_wrData[15:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:14]
         end
       end
     end
-    io_led_REG <= ledReg[15:8]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:27]
-    io_led_REG_1 <= ledReg[6:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 181:67]
+    io_led_REG <= ledReg[15:8]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:27]
+    io_led_REG_1 <= ledReg[6:0]; // @[\\src\\main\\scala\\rvsoc\\RustSoCTop.scala 188:67]
   end
 // Register and memory initialization
 `ifdef RANDOMIZE_GARBAGE_ASSIGN

--- a/wildcat/generated/firrtl_black_box_resource_files.f
+++ b/wildcat/generated/firrtl_black_box_resource_files.f
@@ -1,4 +1,4 @@
-C:\DTU-local\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM.v
-C:\DTU-local\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_1.v
-C:\DTU-local\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_2.v
-C:\DTU-local\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_3.v
+C:\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM.v
+C:\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_1.v
+C:\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_2.v
+C:\Repos\rust-riscv-soc\wildcat\generated\RustSoCTop.ScratchPadMem.MEM_3.v

--- a/wildcat/src/main/scala/rvsoc/RustSoCTop.scala
+++ b/wildcat/src/main/scala/rvsoc/RustSoCTop.scala
@@ -34,6 +34,7 @@ import soc._
  *   0xF000_0000               : UART status  (bit 0 = TX ready, bit 1 = RX data available)
  *   0xF000_0004               : UART data    (read = RX byte, write = TX byte)
  *   0xF010_0000               : LED register  (lower 8 bits drive LEDs)
+ *   0xF020_0000               : Button register (bit 0-3 = btnU, btnL, btnR, btnD)
  *
  * @param frequ     system clock frequency in Hz (default 100 MHz for Basys3)
  * @param baudRate  UART baud rate (default 115200)
@@ -45,6 +46,7 @@ class RustSoCTop(frequ: Int = 100000000, baudRate: Int = 115200, memBytes: Int =
     val led = Output(UInt(16.W))
     val tx  = Output(UInt(1.W))
     val rx  = Input(UInt(1.W))
+    val btn = Input(UInt(4.W))
   })
 
   // ---- Reset monitor ----
@@ -139,7 +141,7 @@ class RustSoCTop(frequ: Int = 100000000, baudRate: Int = 115200, memBytes: Int =
   val uartTx = withReset(combinedReset) { Module(new BufferedTx(frequ, baudRate)) }
   val uartRx = withReset(combinedReset) { Module(new Rx(frequ, baudRate)) }
 
-  // Tx: Opposite of bootloaderTx. It rund when CPU is running.
+  // Tx: Opposite of bootloaderTx. It runs when CPU is running.
   io.tx := Mux(cpuRunning, uartTx.io.txd, 1.U)
   // Rx: Same as Tx
   uartRx.io.rxd := Mux(cpuRunning, io.rx, 1.U)
@@ -161,6 +163,11 @@ class RustSoCTop(frequ: Int = 100000000, baudRate: Int = 115200, memBytes: Int =
       cpu.io.dmem.rdData := uartRx.io.channel.bits
       uartRx.io.channel.ready := cpu.io.dmem.rd
     }
+  }
+
+  // Buttons read at 0xF020_0000
+  when(cpuRunning && (memAddressReg(31, 28) === 0xf.U) && memAddressReg(23, 20) === 2.U) {
+    cpu.io.dmem.rdData := io.btn
   }
 
   // LED register at 0xF010_0000.


### PR DESCRIPTION
Adds memory-mapped GPIO input for the four directional buttons 
(btnU, btnL, btnR, btnD) on the Basys3 board.

## Changes
- RustSoCTop.scala: Added btn input to IO bundle + address decoding at 0xF020_0000
- basys3.xdc: Connected button pins to io_btn[0:3]
- main.rs: Added BTN_REG, btn_read() HAL function, and button-blink demo
- README.md: Added memory map table

## Testing
Requires `make flash` to resynthesise hardware with new button pins,
then `make upload` to load the updated Rust program.
CI hw-test should still pass as "PASS" is printed before the button loop.

## Note
Hardware must be reflashed — `make upload` alone is not sufficient 
since the bitstream needs the new io_btn port.