### PR TITLE
CI: Add Rust crate checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Rust formatting
+        run: cargo fmt --check
+
       - name: Clippy (host tools)
         run: cargo clippy -p uploader -p xtask -- -D warnings
 
       - name: Unit tests (uploader protocol + xtask)
         run: cargo test -p uploader -p xtask
 
+      - name: Compile-check MCU HAL crate
+        run: cargo check -p mcu-hal --target riscv32i-unknown-none-elf
+
+      - name: Compile-check MCU runtime crate
+        run: cargo check -p mcu-rt --target riscv32i-unknown-none-elf
+
       - name: Compile-check on-device program (RISC-V target)
         run: cargo build -p program --target riscv32i-unknown-none-elf --release
+
+      - name: Build HAL API docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p mcu-hal --target riscv32i-unknown-none-elf --no-deps
 
   # ────────────────────────────────────────────────────────────
   # Job 1: Simulation tests (in Github cloud)


### PR DESCRIPTION
What:

- Add CI steps for `cargo fmt --check`.
- Compile-check `mcu-hal` and `mcu-rt` explicitly for `riscv32i-unknown-none-elf`.
- Keep the existing on-device program build step and add HAL Rustdoc with `RUSTDOCFLAGS=-D warnings`.

Why:

- The Rust workspace now has separate HAL and runtime crates, so CI should validate those crate boundaries directly.
- Rustdoc should fail in CI if HAL documentation links break.
- Formatting should be enforced before clippy/build/test work continues.

Result:

- Branch is based on the latest `main` after the merged docs/I2C changes.
- Verified locally: `cargo fmt --check`, `cargo clippy -p uploader -p xtask -- -D warnings`, `cargo test -p uploader -p xtask`, `cargo check -p mcu-hal --target riscv32i-unknown-none-elf`, `cargo check -p mcu-rt --target riscv32i-unknown-none-elf`, `cargo build -p program --target riscv32i-unknown-none-elf --release`, and `RUSTDOCFLAGS="-D warnings" cargo doc -p mcu-hal --target riscv32i-unknown-none-elf --no-deps`.